### PR TITLE
avoid resending entry if object was destroyed

### DIFF
--- a/lib/AnyEvent/Handle/UDP.pm
+++ b/lib/AnyEvent/Handle/UDP.pm
@@ -325,7 +325,7 @@ sub _push_writer {
 				my ($msg, $to, $cv) = @{$entry};
 				my $ret = $self->_send($msg, $to, $cv);
 				if (not defined $ret) {
-					unshift @{$self->_buffers}, $entry;
+					unshift @{$self->_buffers}, $entry if($self->_buffers);
 					last;
 				}
 			}


### PR DESCRIPTION
In case of fatal error $self->destroy is called after on_error callback called.
This patch prevents from pushing entry back to _buffers which is undefined in this case.
