### PR TITLE
'Exiting subroutine via redo' warning 

### DIFF
--- a/lib/AnyEvent/Handle/UDP.pm
+++ b/lib/AnyEvent/Handle/UDP.pm
@@ -166,7 +166,10 @@ sub _bind_to {
 	my $bind_to = sub {
 		my ($domain, $type, $proto, $sockaddr) = @_;
 		if (!Scalar::Util::openhandle($fh)) {
-			socket $fh, $domain, $type, $proto or redo;
+			if (!socket $fh, $domain, $type, $proto) {
+                            $self->_error(1, "Cannot open socket: $!");
+                            return;
+                        }
 			AnyEvent::Util::fh_nonblocking $fh, 1;
 			setsockopt $fh, Socket::SOL_SOCKET, Socket::SO_REUSEADDR, 1 or $self->_error(1, "Couldn't set so_reuseaddr: $!") if $self->{reuse_addr};
 			$add_reader->($self);
@@ -193,7 +196,10 @@ sub _connect_to {
 	my $connect_to = sub {
 		my ($domain, $type, $proto, $sockaddr) = @_;
 		if (!Scalar::Util::openhandle($fh)) {
-			socket $fh, $domain, $type, $proto or redo;
+			if (!socket $fh, $domain, $type, $proto) {
+                            $self->_error(1, "Cannot open socket: $!");
+                            return;
+                        }
 			AnyEvent::Util::fh_nonblocking $fh, 1;
 			$add_reader->($self);
 		}


### PR DESCRIPTION
Hello,

I have observed warning when limit of open files was reached and call to socket() failed:
`Exiting subroutine via redo at /usr/local/share/perl/5.22.1/AnyEvent/Handle/UDP.pm line 196`
The error message passed to on_error callback is 'Could not resolve ip:port', while actual error is 'Bad file descriptor'.
And the next warnings are produced:
 `Use of uninitialized value $proto in socket at /usr/local/share/perl/5.22.1/AnyEvent/Handle/UDP.pm line 196.`
`Use of uninitialized value $type in socket at /usr/local/share/perl/5.22.1/AnyEvent/Handle/UDP.pm line 196.`
`Use of uninitialized value $domain in socket at /usr/local/share/perl/5.22.1/AnyEvent/Handle/UDP.pm line 196.`